### PR TITLE
Fix a KeyError crash when `additional_dependencies` is unspecified

### DIFF
--- a/src/upadup/main.py
+++ b/src/upadup/main.py
@@ -42,7 +42,7 @@ def build_updated_dependency_map(
     hook_config, known_dependency_names, dependency_versions
 ):
     new_deps = {}
-    for current in hook_config["additional_dependencies"]:
+    for current in hook_config.get("additional_dependencies", ()):
         new_dependency = update_dependency(
             current, known_dependency_names, dependency_versions
         )


### PR DESCRIPTION
This prevents a `KeyError` that occurs when a flake8 pre-commit doesn't have `additional_dependencies` set. For example:

```yaml
  - repo: https://github.com/PyCQA/flake8
    rev: 6.0.0
    hooks:
      - id: flake8
```