### PR TITLE
Add a timeout to PyPI JSON requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace
@@ -9,15 +9,15 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - 'flake8-bugbear==24.1.17'
+          - 'flake8-bugbear==24.4.26'
           - 'flake8-comprehensions==3.14.0'
           - 'flake8-typing-as-t==0.0.3'
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/sirosen/slyp
-    rev: 0.3.0
+    rev: 0.6.1
     hooks:
       - id: slyp
   - repo: https://github.com/PyCQA/isort
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,6 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - 'flake8-bugbear==24.4.26'
-          - 'flake8-comprehensions==3.14.0'
-          - 'flake8-typing-as-t==0.0.3'
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.4.2
     hooks:
@@ -29,3 +21,11 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - 'flake8-bugbear==24.4.26'
+          - 'flake8-comprehensions==3.14.0'
+          - 'flake8-typing-as-t==0.0.3'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Timeout after 30 seconds when retrieving JSON from PyPI.
+
 ## 0.0.8
 
 - Add `flake8-logging-format` and `flake8-implicit-str-concat` to default

--- a/src/upadup/package_utils.py
+++ b/src/upadup/package_utils.py
@@ -7,6 +7,8 @@ def normalize_package_name(name: str):
 
 
 def get_pkg_latest(name: str) -> str:
-    with urllib.request.urlopen(f"https://pypi.python.org/pypi/{name}/json") as conn:
+    with urllib.request.urlopen(
+        f"https://pypi.python.org/pypi/{name}/json", timeout=30
+    ) as conn:
         version_data = json.load(conn)
     return str(version_data["info"]["version"])


### PR DESCRIPTION
This morning upadup froze indefinitely while I was doing something else. After returning to the tab, I hit `CTRL+C` and tox informed me that upadup had been sitting idle for almost ten minutes:

```
Traceback (most recent call last):
  File "/home/kurt/dev/detect-pythons/.tox/update/bin/upadup", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/kurt/dev/detect-pythons/.tox/update/lib/python3.12/site-packages/upadup/main.py", line 133, in main
    upadup_config = config.load_upadup_config()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kurt/dev/detect-pythons/.tox/update/lib/python3.12/site-packages/upadup/config.py", line 111, in load_upadup_config
    _populate_map(upadup_config_map, DEFAULT_CONFIG, versions)
  File "/home/kurt/dev/detect-pythons/.tox/update/lib/python3.12/site-packages/upadup/config.py", line 95, in _populate_map
    versions[dep] = get_pkg_latest(dep)
                    ^^^^^^^^^^^^^^^^^^^
  File "/home/kurt/dev/detect-pythons/.tox/update/lib/python3.12/site-packages/upadup/package_utils.py", line 10, in get_pkg_latest
    with urllib.request.urlopen(f"https://pypi.python.org/pypi/{name}/json") as conn:
object address  : 0x77542ede7a60
object refcount : 3
object type     : 0x775430765340
object type name: KeyboardInterrupt
object repr     : KeyboardInterrupt()
lost sys.stderr
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^update: exit -2 (509.04 seconds)
```

This PR adds a timeout to PyPI JSON requests. Exceptions are not caught.