### PR TITLE
Support the new canonical blacken-docs repo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Timeout after 30 seconds when retrieving JSON from PyPI.
+- Support updating dependencies associated with the canonical blacken-docs repo.
 
 ## 0.0.8
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ repos:
           - flake8-pyi
           - flake8-typing-as-t
           - flake8-typing-imports
+
+  - repo: https://github.com/adamchainz/blacken-docs
+    hooks:
+      - id: blacken-docs
+        additional_dependencies:
+          - black
+
+  # Old hook URLs
+  # -------------
+
   - repo: https://github.com/asottile/blacken-docs
     hooks:
       - id: blacken-docs

--- a/src/upadup/config.py
+++ b/src/upadup/config.py
@@ -29,6 +29,16 @@ repos:
           - flake8-pyi
           - flake8-typing-as-t
           - flake8-typing-imports
+
+  - repo: https://github.com/adamchainz/blacken-docs
+    hooks:
+      - id: blacken-docs
+        additional_dependencies:
+          - black
+
+  # Old hook URLs
+  # -------------
+
   - repo: https://github.com/asottile/blacken-docs
     hooks:
       - id: blacken-docs


### PR DESCRIPTION
Exactly what it says on the tin.

Bumped into this while attempting to update another project's pre-commit hooks and dependencies.